### PR TITLE
Fix for 0.9.x versions

### DIFF
--- a/libraries/kong_service_provider.rb
+++ b/libraries/kong_service_provider.rb
@@ -59,7 +59,7 @@ class KongCookbook
     #   kong_supports_action?(:start) #=> true
     # @private
     def kong_supports_action?(action)
-      cmd = shell_out("'#{init_command.delete("'")}' | grep -F #{action}")
+      cmd = shell_out("'#{init_command.delete("'")}' 2>&1 | grep -F #{action}")
       cmd.status.success?
     end
 

--- a/test/unit/libraries/kong_service_provider_spec.rb
+++ b/test/unit/libraries/kong_service_provider_spec.rb
@@ -81,7 +81,7 @@ describe KongCookbook::KongServiceProvider, order: :random do
 
   context '#kong_supports_action?' do
     let(:action) { 'action' }
-    let(:cmd) { "'kong' | grep -F #{action}" }
+    let(:cmd) { "'kong' 2>&1 | grep -F #{action}" }
     before do
       allow(provider).to receive(:shell_out).with(cmd).and_return(shellout)
     end
@@ -104,7 +104,7 @@ describe KongCookbook::KongServiceProvider, order: :random do
       allow(provider).to receive(:shell_out).with(cmd).and_return(shellout)
       %w(start stop restart reload).each do |action|
         allow(provider).to receive(:shell_out)
-          .with("'kong' | grep -F #{action}").and_return(shellout)
+          .with("'kong' 2>&1 | grep -F #{action}").and_return(shellout)
       end
     end
 


### PR DESCRIPTION
kong 0.9.x outputs help to stderr, so it breaks cookbook's service provider logic