### PR TITLE
Add support for Ubuntu 16.04 (Xenial)

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -48,6 +48,12 @@ platforms:
     flavor: 512MB
   run_list: recipe[apt]
 
+- name: ubuntu-16-04-x64
+  driver_plugin: digitalocean
+  driver_config:
+    flavor: 512MB
+  run_list: recipe[apt]
+
 - name: amazon-2015.09.2
   driver_plugin: ec2
   driver_config:

--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -21,3 +21,5 @@ platforms:
   run_list: recipe[apt]
 - name: ubuntu-15.04
   run_list: recipe[apt]
+- name: ubuntu-16.04
+  run_list: recipe[apt]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -32,6 +32,8 @@ platforms:
   run_list: recipe[apt]
 - name: ubuntu-15.04
   run_list: recipe[apt]
+- name: ubuntu-16.04
+  run_list: recipe[apt]
 
 suites:
 - name: default

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -61,6 +61,11 @@ when 'debian'
       default['kong']['package_file'] = 'kong-%{version}.vivid_all.deb'
       default['kong']['package_checksum'] =
         '4c5a7c4ef3d5c1bf34f51ed2743febc863013182be04b992239eb42bb7eb25ef'
+    when 16.04
+      default['kong']['version'] = '0.8.3' # version 0.8.2 is not supported
+      default['kong']['package_file'] = 'kong-%{version}.xenial_all.deb'
+      default['kong']['package_checksum'] =
+        '4e2fcdaaee8983176425af72bbb47a72164249407e04695c55d7bc67820bb6d1'
     else raise "Unsupported Ubuntu version: #{node['platform_version']}"
     end
   end

--- a/test/unit/recipes/_from_package_spec.rb
+++ b/test/unit/recipes/_from_package_spec.rb
@@ -108,6 +108,12 @@ describe 'kong::_from_package', order: :random do
                    package: "kong-#{version}.vivid_all.deb",
                    requirements: debian_requirements
 
+  include_examples 'test platform', 'ubuntu@16.04',
+                   # Earlier versions are not available for Ubuntu 16:
+                   version: '0.8.3',
+                   package: 'kong-0.8.3.xenial_all.deb',
+                   requirements: debian_requirements
+
   include_examples 'test platform', 'centos@5.10',
                    package: "kong-#{version}.el5.noarch.rpm",
                    requirements: centos_requirements


### PR DESCRIPTION
Adds support for Ubuntu 16.04 (Xenial).

Used default version `0.8.3` for this distro since that was the first version which shipped a Xenial deb package.